### PR TITLE
lib/theme: use `_command_exists()`

### DIFF
--- a/themes/base.theme.bash
+++ b/themes/base.theme.bash
@@ -386,23 +386,22 @@ function hg_prompt_vars {
 	fi
 }
 
-function node_command_version_prompt {
+function node_command_version_prompt() {
 	local node_version
-	local node_command="$(command -v node)"
-	if [[ -n "${node_command}" ]]; then
-		node_version="$(${node_command} --version 2>/dev/null)"
+	if _command_exists node; then
+		node_version="$(node --version 2> /dev/null)"
 		if [[ -n ${node_version} ]]; then
 			echo -e "${NVM_THEME_PROMPT_PREFIX}${node_version}${NVM_THEME_PROMPT_SUFFIX}"
 		fi
 	fi
 }
 
-function node_version_prompt {
+function node_version_prompt() {
 	local node_version="$(nvm_version_prompt)"
 	if [[ -z "${node_version}" ]]; then
 		node_version="$(node_command_version_prompt)"
 	fi
-	if [[ -n "${node_version}" ]] ; then
+	if [[ -n "${node_version}" ]]; then
 		echo -e "${node_version}"
 	fi
 }


### PR DESCRIPTION
## Description
- Use `_command_exists node` instead of `command -v node`.
- Remove spurious space character, which was causing pre-commit hook failure.

## Motivation and Context
@kigster, if you accept this PR on your fork, then it will automatically update your PR on the main repo.

## How Has This Been Tested?

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
